### PR TITLE
Use long for User id to prevent overflow exceptions

### DIFF
--- a/source/telega/telegram/basic.d
+++ b/source/telega/telegram/basic.d
@@ -22,7 +22,7 @@ version (unittest)
 
 struct User
 {
-    int    id;
+    long   id;
     bool   is_bot;
     string first_name;
 


### PR DESCRIPTION
Using 32bit integer results in overflow exceptions during user serialization in certain cases - Changing to 64bit integers resolves this issue.